### PR TITLE
Initialize project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# ExpertMatch
+
+ExpertMatch is a web platform that connects academic and industry experts with organizations seeking specialized skills. This repository contains a minimal starter implementation using Python + FastAPI for the backend, a placeholder React frontend, and Terraform configuration for AWS infrastructure.
+
+## Repository Structure
+
+- `backend/` – FastAPI application and server code
+- `frontend/` – Placeholder for a React single page application
+- `infra/` – Terraform templates for AWS resources
+
+## Quickstart
+
+1. **Backend**
+   - `cd backend`
+   - Install dependencies with `pip install -r requirements.txt`
+   - Run the development server with `uvicorn app.main:app --reload`
+
+2. **Frontend**
+   - `cd frontend`
+   - Install Node dependencies with `npm install`
+   - Start the development server with `npm start`
+
+3. **Terraform**
+   - `cd infra`
+   - Initialize with `terraform init`
+   - Review variables in `terraform.tfvars`
+   - Deploy with `terraform apply`
+
+This skeleton is meant as a starting point for implementing the full ExpertMatch platform. Consult the project specification for more details.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./expertmatch.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,61 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas, database
+
+models.Base.metadata.create_all(bind=database.engine)
+
+app = FastAPI(title="ExpertMatch API")
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/experts/", response_model=schemas.Expert)
+def create_expert(expert: schemas.ExpertCreate, db: Session = Depends(get_db)):
+    db_expert = models.Expert(**expert.dict())
+    db.add(db_expert)
+    db.commit()
+    db.refresh(db_expert)
+    return db_expert
+
+
+@app.get("/experts/{expert_id}", response_model=schemas.Expert)
+def read_expert(expert_id: int, db: Session = Depends(get_db)):
+    db_expert = db.query(models.Expert).filter(models.Expert.id == expert_id).first()
+    if not db_expert:
+        raise HTTPException(status_code=404, detail="Expert not found")
+    return db_expert
+
+
+@app.post("/projects/", response_model=schemas.Project)
+def create_project(project: schemas.ProjectCreate, db: Session = Depends(get_db)):
+    db_project = models.Project(**project.dict())
+    db.add(db_project)
+    db.commit()
+    db.refresh(db_project)
+    return db_project
+
+
+@app.get("/projects/{project_id}", response_model=schemas.Project)
+def read_project(project_id: int, db: Session = Depends(get_db)):
+    db_project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if not db_project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return db_project
+
+
+@app.get("/projects/{project_id}/matches")
+def match_experts(project_id: int, db: Session = Depends(get_db)):
+    """Placeholder match endpoint. Returns all experts for now."""
+    project = db.query(models.Project).filter(models.Project.id == project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    experts = db.query(models.Expert).all()
+    # TODO: replace with real similarity search against OpenSearch
+    return {"project": project, "experts": experts}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class Expert(Base):
+    __tablename__ = "experts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    biography = Column(String, nullable=True)
+    location = Column(String, nullable=True)
+    availability = Column(String, nullable=True)
+    email = Column(String, nullable=False, unique=True)
+    phone = Column(String, nullable=True)
+    desired_work = Column(String, nullable=True)
+    hourly_rate = Column(Float, nullable=True)
+    cv_s3_key = Column(String, nullable=True)
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    organization_name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    qualifications = Column(String, nullable=True)
+    start_date = Column(String, nullable=True)
+    end_date = Column(String, nullable=True)
+    funding_min = Column(Float, nullable=True)
+    funding_max = Column(Float, nullable=True)
+    days_per_week = Column(String, nullable=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,47 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+
+class ExpertBase(BaseModel):
+    name: str
+    biography: Optional[str] = None
+    location: Optional[str] = None
+    availability: Optional[str] = None
+    email: EmailStr
+    phone: Optional[str] = None
+    desired_work: Optional[str] = None
+    hourly_rate: Optional[float] = None
+    cv_s3_key: Optional[str] = None
+
+
+class ExpertCreate(ExpertBase):
+    pass
+
+
+class Expert(ExpertBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ProjectBase(BaseModel):
+    organization_name: str
+    description: Optional[str] = None
+    qualifications: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    funding_min: Optional[float] = None
+    funding_max: Optional[float] = None
+    days_per_week: Optional[str] = None
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class Project(ProjectBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+httpx
+email_validator

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,3 @@
+// Placeholder React-like interface using vanilla JS
+const root = document.getElementById('root');
+root.innerHTML = '<h1>ExpertMatch coming soon</h1>';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>ExpertMatch</title>
+</head>
+<body>
+    <div id="root">Loading...</div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "expertmatch-frontend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "npx serve ."
+  },
+  "dependencies": {}
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,7 @@
+# Infrastructure
+
+This directory contains Terraform configuration used to provision AWS resources for ExpertMatch.
+
+The templates are minimal and should be expanded to include Cognito, Aurora Serverless, Lambda functions, and OpenSearch.
+
+Run `terraform init` followed by `terraform apply` to deploy.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "cv_bucket" {
+  bucket = var.cv_bucket
+  force_destroy = true
+}
+
+# Additional resources like Cognito, Aurora, and OpenSearch would be defined here.

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "cv_bucket" {
+  type    = string
+  default = "expert-match-cv-dev"
+}


### PR DESCRIPTION
## Summary
- start ExpertMatch project from scratch
- add FastAPI backend with Expert and Project models
- set up basic frontend placeholder
- create Terraform skeleton for AWS infra
- document quickstart in README

## Testing
- `python -m pip install --quiet -r backend/requirements.txt`
- `python - <<'EOF'
from fastapi.testclient import TestClient
from backend.app.main import app
client = TestClient(app)
resp = client.post('/experts/', json={'name':'Alice','email':'alice@example.com'})
print('status', resp.status_code)
print(resp.json())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683f580e3d0083248d53791ba69713b6