### PR TITLE
Pin httpx for Starlette 0.27.0 compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
-httpx
+httpx>=0.22.0
 email_validator


### PR DESCRIPTION
## Summary
- pin httpx version used by Starlette to `>=0.22.0`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5d8025c883249d961b7fe3591341