### PR TITLE
Extend Expert model and add Google Scholar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ ExpertMatch is a web platform that connects academic and industry experts with o
    - `cd backend`
    - Install dependencies with `pip install -r requirements.txt`
    - Run the development server with `uvicorn app.main:app --reload`
+   - Upload CVs or biographies with `POST /experts/{id}/upload_cv` and `/experts/{id}/upload_bio`
+   - Fetch an expert's Google Scholar publications via `POST /experts/{id}/publications/fetch`
 
 2. **Frontend**
    - `cd frontend`

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,18 @@
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from opensearchpy import OpenSearchException
+from pathlib import Path
+import shutil
+from scholarly import scholarly
 
 from . import models, schemas, database
 
 models.Base.metadata.create_all(bind=database.engine)
 
 app = FastAPI(title="ExpertMatch API")
+
+UPLOAD_DIR = Path("uploaded_files")
+UPLOAD_DIR.mkdir(exist_ok=True)
 
 
 def get_db():
@@ -25,12 +31,25 @@ def compute_embedding(text: str) -> list[float]:
     return [float(abs(hash(text)) % 1000)]
 
 
+def build_expert_embedding(expert: models.Expert, publications: list[models.Publication]) -> list[float]:
+    parts = [expert.name or "", expert.biography or "", expert.location or ""]
+    parts += [pub.title for pub in publications]
+    return compute_embedding(" ".join(parts))
+
+
 @app.post("/experts/", response_model=schemas.Expert)
 def create_expert(expert: schemas.ExpertCreate, db: Session = Depends(get_db)):
     db_expert = models.Expert(**expert.dict())
     db.add(db_expert)
     db.commit()
     db.refresh(db_expert)
+    # index in OpenSearch
+    client = database.get_opensearch_client()
+    try:
+        embedding = build_expert_embedding(db_expert, [])
+        client.index(index="experts", id=db_expert.id, body={"id": db_expert.id, "embedding": embedding})
+    except Exception:
+        pass
     return db_expert
 
 
@@ -40,6 +59,73 @@ def read_expert(expert_id: int, db: Session = Depends(get_db)):
     if not db_expert:
         raise HTTPException(status_code=404, detail="Expert not found")
     return db_expert
+
+
+@app.post("/experts/{expert_id}/upload_cv", response_model=schemas.Expert)
+def upload_cv(expert_id: int, file: UploadFile = File(...), db: Session = Depends(get_db)):
+    expert = db.query(models.Expert).filter(models.Expert.id == expert_id).first()
+    if not expert:
+        raise HTTPException(status_code=404, detail="Expert not found")
+    path = UPLOAD_DIR / f"cv_{expert_id}.pdf"
+    with path.open("wb") as f:
+        shutil.copyfileobj(file.file, f)
+    expert.cv_s3_key = str(path)
+    db.commit()
+    db.refresh(expert)
+    return expert
+
+
+@app.post("/experts/{expert_id}/upload_bio", response_model=schemas.Expert)
+def upload_bio(expert_id: int, file: UploadFile = File(...), db: Session = Depends(get_db)):
+    expert = db.query(models.Expert).filter(models.Expert.id == expert_id).first()
+    if not expert:
+        raise HTTPException(status_code=404, detail="Expert not found")
+    path = UPLOAD_DIR / f"bio_{expert_id}.txt"
+    with path.open("wb") as f:
+        shutil.copyfileobj(file.file, f)
+    expert.biography_file_key = str(path)
+    db.commit()
+    db.refresh(expert)
+    return expert
+
+
+@app.post("/experts/{expert_id}/publications/fetch", response_model=list[schemas.Publication])
+def fetch_publications(expert_id: int, db: Session = Depends(get_db)):
+    expert = db.query(models.Expert).filter(models.Expert.id == expert_id).first()
+    if not expert:
+        raise HTTPException(status_code=404, detail="Expert not found")
+    if not expert.google_scholar_url:
+        raise HTTPException(status_code=400, detail="Expert has no Google Scholar URL")
+
+    scholar_id = expert.google_scholar_url.split("user=")[-1].split("&")[0]
+    author = scholarly.search_author_id(scholar_id)
+    author = scholarly.fill(author, sections=["publications"])
+    publications = []
+    for pub in author.get("publications", [])[:5]:
+        filled = scholarly.fill(pub)
+        title = filled.get("bib", {}).get("title", "")
+        year = filled.get("bib", {}).get("pub_year")
+        url = filled.get("pub_url")
+        p = models.Publication(expert_id=expert_id, title=title, year=year, url=url)
+        publications.append(p)
+        db.add(p)
+    db.commit()
+    # update embedding with new publications
+    client = database.get_opensearch_client()
+    embedding = build_expert_embedding(expert, publications)
+    try:
+        client.index(index="experts", id=expert.id, body={"id": expert.id, "embedding": embedding})
+    except Exception:
+        pass
+    return publications
+
+
+@app.get("/experts/{expert_id}/publications", response_model=list[schemas.Publication])
+def list_publications(expert_id: int, db: Session = Depends(get_db)):
+    expert = db.query(models.Expert).filter(models.Expert.id == expert_id).first()
+    if not expert:
+        raise HTTPException(status_code=404, detail="Expert not found")
+    return expert.publications
 
 
 @app.post("/projects/", response_model=schemas.Project)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import Column, Integer, String, Float, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
@@ -10,6 +11,7 @@ class Expert(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     biography = Column(String, nullable=True)
+    biography_file_key = Column(String, nullable=True)
     location = Column(String, nullable=True)
     availability = Column(String, nullable=True)
     email = Column(String, nullable=False, unique=True)
@@ -17,6 +19,9 @@ class Expert(Base):
     desired_work = Column(String, nullable=True)
     hourly_rate = Column(Float, nullable=True)
     cv_s3_key = Column(String, nullable=True)
+    google_scholar_url = Column(String, nullable=True)
+
+    publications = relationship("Publication", back_populates="expert", cascade="all, delete-orphan")
 
 
 class Project(Base):
@@ -31,3 +36,15 @@ class Project(Base):
     funding_min = Column(Float, nullable=True)
     funding_max = Column(Float, nullable=True)
     days_per_week = Column(String, nullable=True)
+
+
+class Publication(Base):
+    __tablename__ = "publications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    expert_id = Column(Integer, ForeignKey("experts.id"), nullable=False)
+    title = Column(String, nullable=False)
+    year = Column(Integer, nullable=True)
+    url = Column(String, nullable=True)
+
+    expert = relationship("Expert", back_populates="publications")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,10 +1,13 @@
-from pydantic import BaseModel, EmailStr
-from typing import Optional
+from __future__ import annotations
+
+from pydantic import BaseModel, EmailStr, validator
+from typing import Optional, List
 
 
 class ExpertBase(BaseModel):
     name: str
     biography: Optional[str] = None
+    biography_file_key: Optional[str] = None
     location: Optional[str] = None
     availability: Optional[str] = None
     email: EmailStr
@@ -12,6 +15,13 @@ class ExpertBase(BaseModel):
     desired_work: Optional[str] = None
     hourly_rate: Optional[float] = None
     cv_s3_key: Optional[str] = None
+    google_scholar_url: Optional[str] = None
+
+    @validator("email")
+    def email_must_be_edu(cls, v):
+        if v and not v.endswith(".edu"):
+            raise ValueError("email must end with .edu")
+        return v
 
 
 class ExpertCreate(ExpertBase):
@@ -19,6 +29,20 @@ class ExpertCreate(ExpertBase):
 
 
 class Expert(ExpertBase):
+    id: int
+    publications: List['Publication'] = []
+
+    class Config:
+        orm_mode = True
+
+
+class PublicationBase(BaseModel):
+    title: str
+    year: Optional[int] = None
+    url: Optional[str] = None
+
+
+class Publication(PublicationBase):
     id: int
 
     class Config:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ pydantic
 httpx>=0.22.0
 email_validator
 opensearch-py
+scholarly
+python-multipart

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -27,8 +27,8 @@ def client(tmp_path):
 
 
 def create_sample_data(db):
-    e1 = models.Expert(name="Alice", email="alice@example.com")
-    e2 = models.Expert(name="Bob", email="bob@example.com")
+    e1 = models.Expert(name="Alice", email="alice@example.edu")
+    e2 = models.Expert(name="Bob", email="bob@example.edu")
     p = models.Project(organization_name="Org", description="project")
     db.add_all([e1, e2, p])
     db.commit()


### PR DESCRIPTION
## Summary
- enrich Expert model with biography file key, Google Scholar URL, and publications
- add Publication model and schemas
- validate `.edu` emails for experts
- implement endpoints to upload CV/biography and fetch publications from Google Scholar
- index expert embeddings in OpenSearch
- update tests to reflect email requirement
- document new endpoints in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6d6cf8b0832480a37aaeead34e98